### PR TITLE
Python 3 compatibility via six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Twisted==14.0.0
 pika==0.9.14
-
+six

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Twisted==14.0.0',
-        'pika==0.9.14'
+        'pika==0.9.14',
+        'six',
     ],
     url='http://github.com/SweetIQ/tx-easy-pika',
     keywords=["pika", "rabbitmq", "twisted", "amqpy"],


### PR DESCRIPTION
Thank you for this library!  We need to use `tx-easy-pika` in Python 3, and I thought I'd contribute our (very minor) fixes towards this end.
